### PR TITLE
Include everything under target/copkg into to root.

### DIFF
--- a/src/main/resources/assemblies/copkg.xml
+++ b/src/main/resources/assemblies/copkg.xml
@@ -40,6 +40,15 @@
         <include>**</include>
       </includes>
     </fileSet>
+
+    <fileSet>
+      <!-- Include files that do not fit in bin or etc -->
+      <directory>target/copkg</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
     
     <fileSet>
       <!-- Include include built targets -->


### PR DESCRIPTION
This allows downloading dependencies using maven instead of manually
adding them to src/copkg/lib.
